### PR TITLE
Option to configure bundle url for getting secure bundle

### DIFF
--- a/src/cassio/config/__init__.py
+++ b/src/cassio/config/__init__.py
@@ -33,6 +33,7 @@ def init(
     password: Optional[str] = None,
     cluster_kwargs: Optional[Dict[str, Any]] = None,
     tempfile_basedir: Optional[str] = None,
+    bundle_url_template: Optional[str] = None
 ) -> None:
     """
     Globally set the default Cassandra connection (/keyspace) for CassIO.
@@ -87,6 +88,8 @@ def init(
         `password` (optional str), password for Cassandra connection
         `cluster_kwargs` (optional dict), additional arguments to `Cluster(...)`.
         `tempfile_basedir` (optional str), where to create temporary work directories.
+        `bundle_url_template` (optional str), url template for getting the database
+            secure bundle. The "databaseId" variable is resolved with the actual value.
 
     ASTRA DB:
     The Astra-related parameters are arranged in a chain of fallbacks.
@@ -267,7 +270,7 @@ def init(
                         temp_dir or "", DOWNLOADED_BUNDLE_FILE_NAME
                     )
                     download_astra_bundle_url(
-                        database_id, chosen_token, bundle_from_download
+                        database_id, chosen_token, bundle_from_download, bundle_url_template
                     )
                 # After the devops-api part, re-evaluate chosen_bundle:
                 chosen_bundle = _first_valid(

--- a/src/cassio/config/bundle_download.py
+++ b/src/cassio/config/bundle_download.py
@@ -3,21 +3,24 @@ Facilities to manage the download of a secure-connect-bundle from an Astra DB
 token.
 """
 import requests  # type: ignore
+from typing import Optional
 
 
-GET_BUNDLE_URL_TEMPLATE = (
+DEFAULT_GET_BUNDLE_URL_TEMPLATE = (
     "https://api.astra.datastax.com/v2/databases/{database_id}/secureBundleURL"
 )
 
 
-def get_astra_bundle_url(database_id: str, token: str) -> str:
+def get_astra_bundle_url(database_id: str, token: str, bundle_url_template: Optional[str] = None) -> str:
     """
     Given a database ID and a token, provide a (temporarily-valid)
     URL for downloading the secure-connect-bundle.
 
     Courtesy of @phact (thank you!).
     """
-    url = GET_BUNDLE_URL_TEMPLATE.format(database_id=database_id)
+    if not bundle_url_template:
+        bundle_url_template = DEFAULT_GET_BUNDLE_URL_TEMPLATE
+    url = bundle_url_template.format(database_id=database_id)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -50,11 +53,12 @@ def get_astra_bundle_url(database_id: str, token: str) -> str:
         )
 
 
-def download_astra_bundle_url(database_id: str, token: str, out_file_path: str) -> None:
+def download_astra_bundle_url(database_id: str, token: str, out_file_path: str,
+                              bundle_url_template: Optional[str] = None) -> None:
     """
     Obtain the secure-connect-bundle and save it to a specified file.
     """
-    bundle_url = get_astra_bundle_url(database_id=database_id, token=token)
+    bundle_url = get_astra_bundle_url(database_id=database_id, token=token, bundle_url_template=bundle_url_template)
     bundle_data = requests.get(bundle_url)
     with open(out_file_path, "wb") as f:
         f.write(bundle_data.content)


### PR DESCRIPTION
* New option in `cassio.init()` called `secure_bundle_template` which can be used to use a different url for getting the secure bundle when only database_id and token are specified.

The main reason is to use a non production environment where the bundle url is different. Example for Astra DEV: 
```
cassio.init(database_id="xx", token="AstraCS:yy", bundle_url_template="https://api.dev.cloud.datastax.com/v2/databases/{database_id}/secureBundleURL")
```  