### PR TITLE
added ability to specify options for vector and metadata indexes

### DIFF
--- a/src/cassio/table/cql.py
+++ b/src/cassio/table/cql.py
@@ -26,12 +26,7 @@ CREATE_INDEX_CQL_PREFIX = "CREATE CUSTOM INDEX IF NOT EXISTS {index_name}_{{tabl
 
 CREATE_INDEX_CQL_TEMPLATE = (
     CREATE_INDEX_CQL_PREFIX
-    + "({index_column}) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';"
-)
-
-CREATE_INDEX_ANALYZER_CQL_TEMPLATE = (
-    CREATE_INDEX_CQL_PREFIX
-    + "({index_column}) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = {{{{{body_index_options}}}}};"  # noqa: E501
+    + "({index_column}) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' {options_clause};"
 )
 
 CREATE_KEYS_INDEX_CQL_TEMPLATE = (

--- a/src/cassio/table/cql.py
+++ b/src/cassio/table/cql.py
@@ -26,7 +26,7 @@ CREATE_INDEX_CQL_PREFIX = "CREATE CUSTOM INDEX IF NOT EXISTS {index_name}_{{tabl
 
 CREATE_INDEX_CQL_TEMPLATE = (
     CREATE_INDEX_CQL_PREFIX
-    + "({index_column}) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' {options_clause};"
+    + "({index_column}) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' {options_clause};"  # noqa: E501
 )
 
 CREATE_KEYS_INDEX_CQL_TEMPLATE = (

--- a/src/cassio/table/mixins.py
+++ b/src/cassio/table/mixins.py
@@ -273,7 +273,6 @@ class MetadataMixin(BaseTableMixin):
     def _get_create_entries_index_cql(entries_index_column: str) -> str:
         index_name = f"eidx_{entries_index_column}"
         index_column = f"{entries_index_column}"
-
         create_index_cql = CREATE_ENTRIES_INDEX_CQL_TEMPLATE.format(
             index_name=index_name,
             index_column=index_column,
@@ -581,8 +580,8 @@ class VectorMixin(BaseTableMixin):
         self,
         *pargs: Any,
         vector_dimension: Union[int, Awaitable[int]],
-        vector_similarity_function: Optional[str],
-        vector_source_model: Optional[str],
+        vector_similarity_function: Optional[str] = None,
+        vector_source_model: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         if inspect.isawaitable(vector_dimension) and not kwargs.get(

--- a/src/cassio/table/utils.py
+++ b/src/cassio/table/utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable, Any
+from typing import Any, Callable, Optional
 
 from cassandra.cluster import ResponseFuture
 
@@ -19,3 +19,13 @@ async def call_wrapped_async(
 
     response_future.add_callbacks(success_handler, error_handler)
     return await asyncio_future
+
+
+def get_options_clause(options: Optional[dict] = None) -> str:
+    if options is not None:
+        options_text = ", ".join([f"'{k}': '{v}'" for k, v in options.items()])
+
+        # this is double escaped because the cql will go through
+        # another format method before being executed
+        return f"WITH OPTIONS = {{{{ {options_text} }}}}"
+    return ""

--- a/src/cassio/table/utils.py
+++ b/src/cassio/table/utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Callable, Optional
+from typing import Callable, Any
 
 from cassandra.cluster import ResponseFuture
 
@@ -19,13 +19,3 @@ async def call_wrapped_async(
 
     response_future.add_callbacks(success_handler, error_handler)
     return await asyncio_future
-
-
-def get_options_clause(options: Optional[dict] = None) -> str:
-    if options is not None:
-        options_text = ", ".join([f"'{k}': '{v}'" for k, v in options.items()])
-
-        # this is double escaped because the cql will go through
-        # another format method before being executed
-        return f"WITH OPTIONS = {{{{ {options_text} }}}}"
-    return ""

--- a/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
+++ b/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
@@ -32,7 +32,8 @@ class TestClusteredMetadataVectorCassandraTable:
             keyspace=db_keyspace,
             table=table_name,
             vector_dimension=2,
-            vector_index_options={"similarity_function": "DOT_PRODUCT"},
+            vector_similarity_function="DOT_PRODUCT",
+            vector_source_model="bert",
             primary_key_type=["INT", "TEXT"],
             partition_id=0,
         )

--- a/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
+++ b/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
@@ -33,7 +33,6 @@ class TestClusteredMetadataVectorCassandraTable:
             table=table_name,
             vector_dimension=2,
             vector_similarity_function="DOT_PRODUCT",
-            vector_source_model="bert",
             primary_key_type=["INT", "TEXT"],
             partition_id=0,
         )
@@ -145,6 +144,25 @@ class TestClusteredMetadataVectorCassandraTable:
             _ = t_xpart.get(row_id="not_enough_info")
 
         t.clear()
+
+    @pytest.mark.skipif(
+        os.getenv("TEST_DB_MODE", "LOCAL_CASSANDRA") != "ASTRA_DB",
+        reason="requires a test Astra DB instance",
+    )
+    def test_vector_source_model_parameter(
+        self, db_session: Session, db_keyspace: str
+    ) -> None:
+        table_name = "c_m_v_ct_sm"
+        db_session.execute(f"DROP TABLE IF EXISTS {db_keyspace}.{table_name};")
+        #
+        ClusteredMetadataVectorCassandraTable(
+            session=db_session,
+            keyspace=db_keyspace,
+            table=table_name,
+            vector_dimension=2,
+            vector_similarity_function="DOT_PRODUCT",
+            vector_source_model="bert",
+        )
 
     @pytest.mark.skipif(
         TEST_DB_MODE in {"LOCAL_CASSANDRA", "TESTCONTAINERS_CASSANDRA"},

--- a/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
+++ b/tests/integration/test_tableclasses_clusteredmetadatavectorcassandratable.py
@@ -32,6 +32,7 @@ class TestClusteredMetadataVectorCassandraTable:
             keyspace=db_keyspace,
             table=table_name,
             vector_dimension=2,
+            vector_index_options={"similarity_function": "DOT_PRODUCT"},
             primary_key_type=["INT", "TEXT"],
             partition_id=0,
         )

--- a/tests/unit/test_tableclasses_cql_generation.py
+++ b/tests/unit/test_tableclasses_cql_generation.py
@@ -15,6 +15,7 @@ class TestTableClassesCQLGeneration:
             keyspace="k",
             table="tn",
             vector_dimension=765,
+            vector_index_options={"similarity_function": "DOT_PRODUCT"},
             primary_key_type="UUID",
         )
         mock_db_session.assert_last_equal(
@@ -24,7 +25,7 @@ class TestTableClassesCQLGeneration:
                     tuple(),
                 ),
                 (
-                    "CREATE CUSTOM INDEX IF NOT EXISTS idx_vector_tn ON k.tn (vector) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';",  # noqa: E501
+                    "CREATE CUSTOM INDEX IF NOT EXISTS idx_vector_tn ON k.tn (vector) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'similarity_function': 'dot_product' };",  # noqa: E501
                     tuple(),
                 ),
             ]
@@ -99,6 +100,7 @@ class TestTableClassesCQLGeneration:
             primary_key_type=["PUUID", "AT", "BT"],
             ttl_seconds=123,
             partition_id="PRE-PART-ID",
+            metadata_index_options={"c": "d", "e": "f"},
         )
         mock_db_session.assert_last_equal(
             [
@@ -111,7 +113,7 @@ class TestTableClassesCQLGeneration:
                     tuple(),
                 ),
                 (
-                    "CREATE CUSTOM INDEX IF NOT EXISTS eidx_metadata_s_tn ON k.tn (ENTRIES(metadata_s)) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';",  # noqa: E501
+                    "CREATE CUSTOM INDEX IF NOT EXISTS eidx_metadata_s_tn ON k.tn (ENTRIES(metadata_s)) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'c': 'd', 'e': 'f' };",  # noqa: E501
                     tuple(),
                 ),
             ]

--- a/tests/unit/test_tableclasses_cql_generation.py
+++ b/tests/unit/test_tableclasses_cql_generation.py
@@ -15,7 +15,8 @@ class TestTableClassesCQLGeneration:
             keyspace="k",
             table="tn",
             vector_dimension=765,
-            vector_index_options={"similarity_function": "DOT_PRODUCT"},
+            vector_similarity_function="DOT_PRODUCT",
+            vector_source_model="bert",
             primary_key_type="UUID",
         )
         mock_db_session.assert_last_equal(
@@ -100,7 +101,6 @@ class TestTableClassesCQLGeneration:
             primary_key_type=["PUUID", "AT", "BT"],
             ttl_seconds=123,
             partition_id="PRE-PART-ID",
-            metadata_index_options={"c": "d", "e": "f"},
         )
         mock_db_session.assert_last_equal(
             [
@@ -113,7 +113,7 @@ class TestTableClassesCQLGeneration:
                     tuple(),
                 ),
                 (
-                    "CREATE CUSTOM INDEX IF NOT EXISTS eidx_metadata_s_tn ON k.tn (ENTRIES(metadata_s)) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'c': 'd', 'e': 'f' };",  # noqa: E501
+                    "CREATE CUSTOM INDEX IF NOT EXISTS eidx_metadata_s_tn ON k.tn (ENTRIES(metadata_s)) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';",  # noqa: E501
                     tuple(),
                 ),
             ]

--- a/tests/unit/test_tableclasses_cql_generation.py
+++ b/tests/unit/test_tableclasses_cql_generation.py
@@ -26,7 +26,7 @@ class TestTableClassesCQLGeneration:
                     tuple(),
                 ),
                 (
-                    "CREATE CUSTOM INDEX IF NOT EXISTS idx_vector_tn ON k.tn (vector) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'similarity_function': 'dot_product' };",  # noqa: E501
+                    "CREATE CUSTOM INDEX IF NOT EXISTS idx_vector_tn ON k.tn (vector) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'similarity_function': 'dot_product', 'source_model': 'bert' };",  # noqa: E501
                     tuple(),
                 ),
             ]


### PR DESCRIPTION
related to https://github.com/CassioML/cassio/issues/36, but I'm wondering if my approach is too general. 

Should we just have an option to set `WITH OPTIONS = { 'similarity_function': 'dot_product' }` and not worry about the general use case?

Let me know your thoughts 