### PR TITLE
feat: add cloud_kwargs to configure connect_timeout to /metadata endpoint

### DIFF
--- a/src/cassio/config/__init__.py
+++ b/src/cassio/config/__init__.py
@@ -33,6 +33,7 @@ def init(
     cluster_kwargs: Optional[Dict[str, Any]] = None,
     tempfile_basedir: Optional[str] = None,
     bundle_url_template: Optional[str] = None,
+    cloud_kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Globally set the default Cassandra connection (/keyspace) for CassIO.
@@ -91,6 +92,7 @@ def init(
             secure bundle. The "databaseId" variable is resolved with the actual value.
             Default (for Astra DB):
                 "https://api.astra.datastax.com/v2/databases/{database_id}/secureBundleURL"
+        `cloud_kwargs` (optional dict), additional arguments to `Cluster(cloud={...})`.
 
     ASTRA DB:
     The Astra-related parameters are arranged in a chain of fallbacks.
@@ -283,7 +285,9 @@ def init(
                 if chosen_bundle:
                     keyspace_from_bundle = infer_keyspace_from_bundle(chosen_bundle)
                     cluster = Cluster(
-                        cloud={"secure_connect_bundle": chosen_bundle},
+                        cloud={"secure_connect_bundle": chosen_bundle,
+                               **(cloud_kwargs if cloud_kwargs is not None else {})
+                        },
                         auth_provider=PlainTextAuthProvider(
                             ASTRA_CLOUD_AUTH_USERNAME,
                             chosen_token,

--- a/src/cassio/config/__init__.py
+++ b/src/cassio/config/__init__.py
@@ -287,7 +287,7 @@ def init(
                     cluster = Cluster(
                         cloud={"secure_connect_bundle": chosen_bundle,
                                **(cloud_kwargs if cloud_kwargs is not None else {})
-                        },
+                               },
                         auth_provider=PlainTextAuthProvider(
                             ASTRA_CLOUD_AUTH_USERNAME,
                             chosen_token,

--- a/tests/integration/test_init_astra.py
+++ b/tests/integration/test_init_astra.py
@@ -104,6 +104,14 @@ class TestInitAstra:
         assert resolve_session() is not None
         assert resolve_keyspace() is not None
 
+    def test_init_scb_cloudkwargs(self) -> None:
+        _reset_cassio_globals()
+        scb = os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"]
+        tok = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
+        cassio.init(secure_connect_bundle=scb, token=tok, cloud_kwargs={"connect_timeout": 30})
+        assert resolve_keyspace() is not None  # through inspecting the scb
+        assert resolve_session() is not None
+
     @pytest.mark.skipif(
         os.environ.get("ASTRA_DB_DATABASE_ID") is None,
         reason="requires the database ID to download the secure bundle",

--- a/tests/integration/test_init_astra.py
+++ b/tests/integration/test_init_astra.py
@@ -108,7 +108,9 @@ class TestInitAstra:
         _reset_cassio_globals()
         scb = os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"]
         tok = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
-        cassio.init(secure_connect_bundle=scb, token=tok, cloud_kwargs={"connect_timeout": 30})
+        cassio.init(
+            secure_connect_bundle=scb, token=tok, cloud_kwargs={"connect_timeout": 30}
+        )
         assert resolve_keyspace() is not None  # through inspecting the scb
         assert resolve_session() is not None
 


### PR DESCRIPTION
In order to connect in this way and set the connect_timeout, I'd need to pass more options to cluster.cloud:
```
cluster = Cluster(
    cloud={
        "secure_connect_bundle": ASTRA_DB_SECURE_BUNDLE_PATH,
	"connect_timeout": 30,
    },
    ...
)
```

Changes:
- Added `cloud_kwargs` dict to `cassio.init()`. Example usage: 
```
cassio.init(secure_connect_bundle=scb, token=tok, cloud_kwargs={"connect_timeout": 30})
```