### PR TITLE
Introduce default proto V4 w/ fallback (Astra DB). Alias ASTRA_DB_ID

### DIFF
--- a/.github/workflows/astradb.yml
+++ b/.github/workflows/astradb.yml
@@ -12,7 +12,7 @@ jobs:
   test-astradb:
     env:
       ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-      ASTRA_DB_DATABASE_ID: ${{ secrets.ASTRA_DB_DATABASE_ID }}
+      ASTRA_DB_ID: ${{ secrets.ASTRA_DB_ID }}
       ASTRA_DB_INIT_STRING: ${{ secrets.ASTRA_DB_INIT_STRING }}
       ASTRA_DB_KEYSPACE: ${{ secrets.ASTRA_DB_KEYSPACE }}
       ASTRA_DB_SECURE_BUNDLE_PATH: ${{ secrets.ASTRA_DB_SECURE_BUNDLE_PATH }}
@@ -34,7 +34,7 @@ jobs:
 
     - name: Get SCB
       run: |
-        poetry run python -c 'import os; from cassio.config.bundle_download import download_astra_bundle_url; download_astra_bundle_url(database_id=os.environ["ASTRA_DB_DATABASE_ID"], token=os.environ["ASTRA_DB_APPLICATION_TOKEN"], out_file_path=os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"])'
+        poetry run python -c 'import os; from cassio.config.bundle_download import download_astra_bundle_url; download_astra_bundle_url(database_id=os.environ["ASTRA_DB_ID"], token=os.environ["ASTRA_DB_APPLICATION_TOKEN"], out_file_path=os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"])'
 
     - name: Integration tests
       run: |

--- a/TEMPLATE.testing.env
+++ b/TEMPLATE.testing.env
@@ -8,7 +8,7 @@ export TEST_DB_MODE="ASTRA_DB"  # "ASTRA_DB" / "TESTCONTAINERS_CASSANDRA" / "LOC
 export ASTRA_DB_SECURE_BUNDLE_PATH="/path/to/scb.zip"
 export ASTRA_DB_APPLICATION_TOKEN="AstraCS:blablabla"
 export ASTRA_DB_KEYSPACE="cassio_tutorials"
-export ASTRA_DB_DATABASE_ID="ffffffff-ffff-ffff-ffff-ffffffffffff"
+export ASTRA_DB_ID="ffffffff-ffff-ffff-ffff-ffffffffffff"
 
 # for testing the init-string init() method.
 #   Create this with `cassio-create-init-string <bundle file> <keyspace> <token>`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,14 +60,14 @@ def db_session(cassandra_port: int) -> Iterator[Session]:
         ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
         if "ASTRA_DB_SECURE_BUNDLE_PATH" in os.environ:
             ASTRA_DB_SECURE_BUNDLE_PATH = os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"]
-        elif "ASTRA_DB_DATABASE_ID" in os.environ:
+        elif "ASTRA_DB_ID" in os.environ:
             secure_bundle_dir = TemporaryDirectory()
-            ASTRA_DB_DATABASE_ID = os.environ["ASTRA_DB_DATABASE_ID"]
+            ASTRA_DB_ID = os.environ["ASTRA_DB_ID"]
             ASTRA_DB_SECURE_BUNDLE_PATH = os.path.join(
                 secure_bundle_dir.name, "secure-connect-bundle_devopsapi.zip"
             )
             download_astra_bundle_url(
-                ASTRA_DB_DATABASE_ID,
+                ASTRA_DB_ID,
                 ASTRA_DB_APPLICATION_TOKEN,
                 ASTRA_DB_SECURE_BUNDLE_PATH,
             )

--- a/tests/integration/test_init_astra.py
+++ b/tests/integration/test_init_astra.py
@@ -109,12 +109,12 @@ class TestInitAstra:
         assert resolve_session() is not None
 
     @pytest.mark.skipif(
-        os.environ.get("ASTRA_DB_DATABASE_ID") is None,
+        os.environ.get("ASTRA_DB_ID") is None,
         reason="requires the database ID to download the secure bundle",
     )
     def test_init_download_scb(self) -> None:
         _reset_cassio_globals()
-        dbid = os.environ["ASTRA_DB_DATABASE_ID"]
+        dbid = os.environ["ASTRA_DB_ID"]
         tok = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
         kys = os.environ["ASTRA_DB_KEYSPACE"]
         cassio.init(database_id=dbid, token=tok, keyspace=kys)
@@ -122,12 +122,12 @@ class TestInitAstra:
         assert resolve_keyspace() is not None
 
     @pytest.mark.skipif(
-        os.environ.get("ASTRA_DB_DATABASE_ID") is None,
+        os.environ.get("ASTRA_DB_ID") is None,
         reason="requires the database ID to download the secure bundle",
     )
     def test_init_download_scb_url_template(self) -> None:
         _reset_cassio_globals()
-        dbid = os.environ["ASTRA_DB_DATABASE_ID"]
+        dbid = os.environ["ASTRA_DB_ID"]
         tok = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
         kys = os.environ["ASTRA_DB_KEYSPACE"]
         with pytest.raises(Exception):

--- a/tests/integration/test_init_cassandra.py
+++ b/tests/integration/test_init_cassandra.py
@@ -143,7 +143,7 @@ class TestInitCassandra:
                 "ASTRA_DB_INIT_STRING",
                 "ASTRA_DB_SECURE_BUNDLE_PATH",
                 "ASTRA_DB_KEYSPACE",
-                "ASTRA_DB_DATABASE_ID",
+                "ASTRA_DB_ID",
             ]
         )
         cassio.init(auto=True, cluster_kwargs={"port": cassandra_port})


### PR DESCRIPTION
This PR addresses two longstanding issues.

Fixes #123 
Fixes #117 

## Details for #123:

The Cassandra drivers receive, and duly report, an "error" from the database in case protocol version negotiation takes place with Astra that ends up on the current Astra DB version, V4. This surfaces as an error (which confuses/scares users), despite the application then running regularly after that. In order to avoid this "error", one has to explicitly provide the right protocol version. This PR does that, in the case of the Astra DB path for `cassio.init`. The whole protocol-specifying part is wrapped in a try-except that falls back to the regular no-protocol behaviour: should Astra DB ever change its protocol, the worst that happens is the user gets the "error" again and execution continues just fine.

## Details for #117 :

Almost anywhere else, the standard name for the env. variable with the database ID is `ASTRA_DB_ID`. This PR switches to using that as the standard naming, but preserves complete compatibility with the previous name `ASTRA_DB_DATABASE_ID`.
