### PR TITLE
Bugfix: metadata updates are consistent re: attributes/indexed, + tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Bugfix: find_and_delete_entries (metadata mixin) made compatible with clustered 
 Added testing for find_and_delete_entries:
   - with clustered mixin and all call patterns (w/out partition, w/out row_id)
   - enhanced testing on simple metadata table (with counting checks, all call patterns)
+Bugfix: metadata updates completely replace, consistently, the preexisting metadata
+  - with specific tests
 
 v 0.1.9
 =======

--- a/src/cassio/table/base_table.py
+++ b/src/cassio/table/base_table.py
@@ -169,7 +169,9 @@ class BaseTable:
             tuple(where_clause_vals),
         )
 
-    def _normalize_kwargs(self, args_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def _normalize_kwargs(
+        self, args_dict: Dict[str, Any], is_write: bool
+    ) -> Dict[str, Any]:
         new_args_dict = handle_multicolumn_unpacking(
             args_dict,
             "row_id",
@@ -191,7 +193,7 @@ class BaseTable:
         return repacked_row
 
     def _delete(self, is_async: bool, **kwargs: Any) -> Union[None, ResponseFuture]:
-        n_kwargs = self._normalize_kwargs(kwargs)
+        n_kwargs = self._normalize_kwargs(kwargs, is_write=False)
         (
             rest_kwargs,
             where_clause_blocks,
@@ -277,7 +279,7 @@ class BaseTable:
     def _parse_select_core_params(
         self, **kwargs: Any
     ) -> Tuple[str, str, Tuple[Any, ...]]:
-        n_kwargs = self._normalize_kwargs(kwargs)
+        n_kwargs = self._normalize_kwargs(kwargs, is_write=False)
         # TODO: work on a columns: Optional[List[str]] = None
         # (but with nuanced handling of the column-magic we have here)
         columns = None
@@ -359,7 +361,7 @@ class BaseTable:
         return self._normalize_result_set(result_set)
 
     def _put(self, is_async: bool, **kwargs: Any) -> Union[None, ResponseFuture]:
-        n_kwargs = self._normalize_kwargs(kwargs)
+        n_kwargs = self._normalize_kwargs(kwargs, is_write=True)
         primary_key = self._schema_primary_key()
         assert set(col for col, _ in primary_key) - set(n_kwargs.keys()) == set()
         columns = [col for col, _ in self._schema_collist() if col in n_kwargs]

--- a/src/cassio/table/mixins/clustered.py
+++ b/src/cassio/table/mixins/clustered.py
@@ -92,7 +92,9 @@ class ClusteredMixin(BaseTableMixin):
     ) -> None:
         await call_wrapped_async(self.delete_partition_async, partition_id=partition_id)
 
-    def _normalize_kwargs(self, args_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def _normalize_kwargs(
+        self, args_dict: Dict[str, Any], is_write: bool
+    ) -> Dict[str, Any]:
         # if partition id provided in call, takes precedence over instance value
         arg_pid = args_dict.get("partition_id")
         instance_pid = self.partition_id
@@ -108,7 +110,7 @@ class ClusteredMixin(BaseTableMixin):
             [col for col, _ in self._schema_pk()],
         )
 
-        return super()._normalize_kwargs(new_args_dict)
+        return super()._normalize_kwargs(new_args_dict, is_write=is_write)
 
     def _normalize_row(self, raw_row: Any) -> Dict[str, Any]:
         pre_normalized = super()._normalize_row(raw_row)
@@ -142,7 +144,8 @@ class ClusteredMixin(BaseTableMixin):
             {
                 **{"partition_id": _partition_id},
                 **kwargs,
-            }
+            },
+            is_write=False,
         )
         (
             rest_kwargs,

--- a/src/cassio/table/mixins/elastic_key.py
+++ b/src/cassio/table/mixins/elastic_key.py
@@ -45,7 +45,9 @@ class ElasticKeyMixin(BaseTableMixin):
         else:
             return pre_normalized
 
-    def _normalize_kwargs(self, args_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def _normalize_kwargs(
+        self, args_dict: Dict[str, Any], is_write: bool
+    ) -> Dict[str, Any]:
         # transform provided "keys" into the elastic-representation two-val form
         key_args = {k: v for k, v in args_dict.items() if k in self.keys}
         # the "key" is passed all-or-nothing:
@@ -66,7 +68,7 @@ class ElasticKeyMixin(BaseTableMixin):
             }
         else:
             new_args_dict = args_dict
-        return super()._normalize_kwargs(new_args_dict)
+        return super()._normalize_kwargs(new_args_dict, is_write=is_write)
 
     @staticmethod
     def _schema_row_id() -> List[ColumnSpecType]:

--- a/src/cassio/table/mixins/vector.py
+++ b/src/cassio/table/mixins/vector.py
@@ -75,7 +75,7 @@ class VectorMixin(BaseTableMixin):
     def _get_ann_search_cql(
         self, vector: List[float], n: int, **kwargs: Any
     ) -> Tuple[str, Tuple[Any, ...]]:
-        n_kwargs = self._normalize_kwargs(kwargs)
+        n_kwargs = self._normalize_kwargs(kwargs, is_write=False)
         # TODO: work on a columns: Optional[List[str]] = None
         # (but with nuanced handling of the column-magic we have here)
         columns = None

--- a/tests/unit/test_tableclasses_cql_generation.py
+++ b/tests/unit/test_tableclasses_cql_generation.py
@@ -219,10 +219,11 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (body_blob, vector, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?, ?);",  # noqa: E501
+                    "INSERT INTO k.tn (body_blob, vector, attributes_blob, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?, ?, ?);",  # noqa: E501
                     (
                         "BODYBLOB",
                         "VECTOR",
+                        None,
                         {
                             "str1": "STR1",
                             "num1": "123.0",
@@ -247,10 +248,11 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (body_blob, vector, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?, ?);",  # noqa: E501
+                    "INSERT INTO k.tn (body_blob, vector, attributes_blob, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?, ?, ?);",  # noqa: E501
                     (
                         "BODYBLOB",
                         "VECTOR",
+                        None,
                         {"tru2": "true", "tru1": "true"},
                         1,
                         2,
@@ -264,8 +266,9 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?);",  # noqa: E501
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?);",  # noqa: E501
                     (
+                        None,
                         {"tru2": "true", "tru1": "true"},
                         1,
                         2,
@@ -279,8 +282,9 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?);",  # noqa: E501
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id_0, row_id_1, partition_id) VALUES (?, ?, ?, ?, ?);",  # noqa: E501
                     (
+                        None,
                         {'link_{"kind": "kw"}': "link"},
                         1,
                         2,
@@ -533,10 +537,11 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (body_blob, vector, metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
+                    "INSERT INTO k.tn (body_blob, vector, attributes_blob, metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
                     (
                         "BODYBLOB",
                         "VECTOR",
+                        None,
                         {
                             "str1": "STR1",
                             "num1": "123.0",
@@ -563,10 +568,11 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (body_blob, vector, metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
+                    "INSERT INTO k.tn (body_blob, vector, attributes_blob, metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
                     (
                         "BODYBLOB",
                         "VECTOR",
+                        None,
                         {"tru2": "true", "tru1": "true"},
                         '["a","b"]',
                         '["A","B"]',
@@ -581,8 +587,9 @@ class TestTableClassesCQLGeneration:
         mock_db_session.assert_last_equal(
             [
                 (
-                    "INSERT INTO k.tn (metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, key_desc, key_vals, partition_id) VALUES (?, ?, ?, ?, ?) USING TTL ? ;",  # noqa: E501
                     (
+                        None,
                         {"tru2": "true", "tru1": "true"},
                         '["a","b"]',
                         '["A","B"]',

--- a/tests/unit/test_tableclasses_cql_generation.py
+++ b/tests/unit/test_tableclasses_cql_generation.py
@@ -8,11 +8,109 @@ from cassio.table.query import Predicate, PredicateOperator
 from cassio.table.tables import (
     ClusteredElasticMetadataVectorCassandraTable,
     ClusteredMetadataVectorCassandraTable,
+    MetadataCassandraTable,
     VectorCassandraTable,
 )
 
 
 class TestTableClassesCQLGeneration:
+    def test_metadata_routing(self, mock_db_session: MockDBSession) -> None:
+        """Metadata routing and presence/absence of parts
+        of the metadata for read/write paths.
+        """
+        mt = MetadataCassandraTable(
+            session=mock_db_session,
+            keyspace="k",
+            table="tn",
+            metadata_indexing=("allow", {"indexed"}),
+        )
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "CREATE TABLE IF NOT EXISTS k.tn (  row_id TEXT,   body_blob TEXT, attributes_blob TEXT, metadata_s MAP<TEXT,TEXT>, PRIMARY KEY ( ( row_id )   )) ;",  # noqa: E501
+                    tuple(),
+                ),
+                (
+                    "CREATE CUSTOM INDEX IF NOT EXISTS eidx_metadata_s_tn ON k.tn (ENTRIES(metadata_s)) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';",  # noqa: E501
+                    tuple(),
+                ),
+            ]
+        )
+
+        # WRITE PATH: various insertions (with/out indexed/nonindexed parts)
+        mt.put(row_id="ROWID", metadata={})
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id) VALUES (?, ?, ?)  ;",
+                    (
+                        None,
+                        {},
+                        "ROWID",
+                    ),
+                ),
+            ]
+        )
+        mt.put(row_id="ROWID", metadata={"indexed": "i"})
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id) VALUES (?, ?, ?)  ;",
+                    (
+                        None,
+                        {"indexed": "i"},
+                        "ROWID",
+                    ),
+                ),
+            ]
+        )
+        mt.put(row_id="ROWID", metadata={"blobby": "b"})
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id) VALUES (?, ?, ?)  ;",
+                    (
+                        '{"blobby":"b"}',
+                        {},
+                        "ROWID",
+                    ),
+                ),
+            ]
+        )
+        mt.put(row_id="ROWID", metadata={"indexed": "i", "blobby": "b"})
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "INSERT INTO k.tn (attributes_blob, metadata_s, row_id) VALUES (?, ?, ?)  ;",
+                    (
+                        '{"blobby":"b"}',
+                        {"indexed": "i"},
+                        "ROWID",
+                    ),
+                ),
+            ]
+        )
+
+        # READ PATH: various reads (with/out indexed part)
+        mt.get(row_id="ROWID")
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "SELECT * FROM k.tn WHERE row_id = ?;",  # noqa: E501
+                    ("ROWID",),
+                )
+            ]
+        )
+        mt.get(row_id="ROWID", metadata={"indexed": "i"})
+        mock_db_session.assert_last_equal(
+            [
+                (
+                    "SELECT * FROM k.tn WHERE metadata_s['indexed'] = ? AND row_id = ?;",  # noqa: E501
+                    ("i", "ROWID"),
+                ),
+            ]
+        )
+
     def test_vector_cassandra_table(self, mock_db_session: MockDBSession) -> None:
         vt = VectorCassandraTable(
             session=mock_db_session,


### PR DESCRIPTION
This PR brings uniformity in the behaviour of the `put` method(s) when metadata is specified. Previously, depending on whether the "attributes" and "metadata_s" parts were empty or not, different thing would happen to the row on DB because the actual CQL write would either mention the column or not.
This was bad, since the cassio user has no notion of the split between these two, they only see a "metadata" thing in their rows.

Now the behaviour is consistent regardless of what parts of the metadata actually carry content: each metadata overwrite does replace the whole (pair of) columns.

Two crucial notes:

- through the introduction of a `is_write` flag to the kwargs normalizer, reads do not result in the un-indexed part ending up in the SELECT queries;
- writes (PUTs) which do not mention metadata at all would not get the two fields, ensuring (as a test now covers) that no accidental overwrites occur.